### PR TITLE
Integrate yaspin spinner

### DIFF
--- a/chat_cli/utils/spinner.py
+++ b/chat_cli/utils/spinner.py
@@ -1,52 +1,63 @@
-"""Terminal spinner animation for indicating progress."""
+"""Spinner utility using yaspin with fallback to a simple implementation."""
+from __future__ import annotations
 
-import itertools
 import sys
+import itertools
 import threading
 import time
 from typing import Optional
 
+try:
+    from yaspin import yaspin  # type: ignore
+except Exception:  # pragma: no cover - optional dep may be missing
+    yaspin = None  # type: ignore
+
 
 class Spinner:
-    """A minimal terminal spinner shown while waiting for the first token.
-
-    Usage:
-        spinner = Spinner(prefix="assistant> ")
-        spinner.start()
-        # do blocking work …
-        spinner.stop()  # ensures the line is reset to `prefix` again
-    """
-
-    _cycle = itertools.cycle("|/-\\")
+    """Display a small spinner next to a prefix while work is done."""
 
     def __init__(self, prefix: str = "", delay: float = 0.1):
         self._prefix = prefix
         self._delay = delay
-        self._stop_event = threading.Event()
-        self._thread: Optional[threading.Thread] = None
+        self._started = False
+        if yaspin is not None:
+            # spinner after the text so prefix stays at the start
+            self._spinner = yaspin(text=self._prefix, side="right")
+        else:
+            self._cycle = itertools.cycle("|/-\\")
+            self._stop_event = threading.Event()
+            self._thread: Optional[threading.Thread] = None
 
-    def _spin(self) -> None:  # runs in a background thread
+    def _spin(self) -> None:
         while not self._stop_event.is_set():
             ch = next(self._cycle)
-            # Carriage return to beginning-of-line, then redraw prefix + frame
             sys.stdout.write(f"\r{self._prefix}{ch}")
             sys.stdout.flush()
             time.sleep(self._delay)
 
     def start(self) -> None:
-        if self._thread is not None:
-            return  # already running
-        # Print prefix once so we always redraw at same length
-        sys.stdout.write(self._prefix)
-        sys.stdout.flush()
-        self._thread = threading.Thread(target=self._spin, daemon=True)
-        self._thread.start()
+        if self._started:
+            return
+        if yaspin is not None:
+            self._spinner.start()
+        else:
+            sys.stdout.write(self._prefix)
+            sys.stdout.flush()
+            self._thread = threading.Thread(target=self._spin, daemon=True)
+            self._thread.start()
+        self._started = True
 
     def stop(self) -> None:
-        if self._thread is None:
+        if not self._started:
             return
-        self._stop_event.set()
-        self._thread.join()
-        # Clear spinner character and redraw prefix ready for real text
-        sys.stdout.write(f"\r{self._prefix}")
-        sys.stdout.flush() 
+        if yaspin is not None:
+            self._spinner.stop()
+        else:
+            if self._thread:
+                self._stop_event.set()
+                self._thread.join()
+                self._thread = None
+                self._stop_event.clear()
+            sys.stdout.write(f"\r{self._prefix}")
+            sys.stdout.flush()
+        self._started = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openai
+yaspin

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -16,7 +16,11 @@ class BaseChatCLITest(unittest.TestCase):
         # Patch print to suppress command feedback
         self.print_patcher = patch('builtins.print')
         self.print_patcher.start()
-        
+
+        # Patch spinner to avoid background threads during tests
+        self.spinner_patcher = patch('chat_cli.utils.spinner.Spinner')
+        self.mock_spinner_cls = self.spinner_patcher.start()
+
         # Mock the OpenAI client
         self.mock_client = Mock()
         self.mock_wrapper = OpenAIClientWrapper(self.mock_client)
@@ -37,6 +41,7 @@ class BaseChatCLITest(unittest.TestCase):
         # Stop the patchers
         self.sessions_dir_patcher.stop()
         self.print_patcher.stop()
+        self.spinner_patcher.stop()
         
         # Clean up test session files
         if self.test_sessions_dir.exists():


### PR DESCRIPTION
## Summary
- add `yaspin` dependency
- wrap the spinner utility around `yaspin` with a fallback
- patch tests to stub spinner during runs

## Testing
- `python tests/run_tests.py`