### PR TITLE
Use rich for console output

### DIFF
--- a/chat_cli/cli.py
+++ b/chat_cli/cli.py
@@ -9,6 +9,7 @@ import argparse
 import os
 import sys
 import readline  # noqa: F401 – side-effect: history & line editing
+from rich.panel import Panel
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
@@ -20,10 +21,7 @@ from .core.client import OpenAIClientWrapper
 from .utils import (
     Ansi,
     USER_LABEL,
-    ASSISTANT_LABEL,
-    ERROR_LABEL,
-    WARNING_LABEL,
-    readline_safe_prompt,
+    console,
 )
 
 # ---------------------------------------------------------------------------
@@ -51,32 +49,31 @@ class ChatCLI:
     ) -> Optional[str]:
         """Present *options* as a numbered list and return the user's choice."""
         if not options:
-            print("(no items available)")
+            console.print("(no items available)")
             return None
 
-        print(Ansi.style(title, Ansi.BOLD, Ansi.FG_MAGENTA))
+        console.print(Ansi.style(title, Ansi.BOLD, Ansi.FG_MAGENTA))
         for idx, item in enumerate(options, start=1):
-            star = "← current" if current and item == current else ""
+            star = "\u2190 current" if current and item == current else ""
             colour = Ansi.FG_GREEN if star else Ansi.FG_CYAN
-            print(f"  {idx}. {Ansi.style(item, colour)} {star}")
+            console.print(f"  {idx}. {Ansi.style(item, colour)} {star}")
 
         try:
-            prompt = readline_safe_prompt("Select number (Enter to cancel): ")
-            choice_str = input(prompt).strip()
+            choice_str = console.input("Select number (Enter to cancel): ").strip()
         except (EOFError, KeyboardInterrupt):
-            print()
+            console.print()
             return None
 
         if not choice_str:
             return None  # cancelled
 
         if not choice_str.isdigit():
-            print(Ansi.style("Invalid selection – expected a number.", Ansi.FG_RED))
+            console.print(Ansi.style("Invalid selection – expected a number.", Ansi.FG_RED))
             return None
 
         choice = int(choice_str)
         if not (1 <= choice <= len(options)):
-            print(Ansi.style("Selection out of range.", Ansi.FG_RED))
+            console.print(Ansi.style("Selection out of range.", Ansi.FG_RED))
             return None
 
         return options[choice - 1]
@@ -95,11 +92,11 @@ class ChatCLI:
         if cmd == "/help":
             from . import __doc__ as _doc  # lazy import to avoid circularity
 
-            print(_doc or "(no help available)")
+            console.print(_doc or "(no help available)")
 
         elif cmd == "/exit":
             self.session.save()
-            print("Session saved. Bye!")
+            console.print("Session saved. Bye!")
             return False
 
         elif cmd == "/model":
@@ -109,35 +106,35 @@ class ChatCLI:
                 )
                 if selection and selection in SUPPORTED_MODELS:
                     self.session.model = selection
-                    print(f"[model switched to {self.session.model}]")
+                    console.print(f"[model switched to {self.session.model}]")
                 return True
 
             if len(parts) != 2:
-                print("Usage: /model <model_name>")
+                console.print("Usage: /model <model_name>")
             else:
                 model_name = parts[1]
                 if model_name not in SUPPORTED_MODELS:
-                    print("Unsupported model. Use /models to see the list of supported models.")
+                    console.print("Unsupported model. Use /models to see the list of supported models.")
                 else:
                     self.session.model = model_name
-                    print(f"[model switched to {self.session.model}]")
+                    console.print(f"[model switched to {self.session.model}]")
 
         elif cmd == "/models":
-            print("Supported models:")
+            console.print("Supported models:")
             for m in SUPPORTED_MODELS:
                 marker = " <- current" if m == self.session.model else ""
-                print(f"  {m}{marker}")
+                console.print(f"  {m}{marker}")
 
         elif cmd == "/list":
             self.list_sessions()
 
         elif cmd == "/new":
             if len(parts) != 2:
-                print("Usage: /new <session_name>")
+                console.print("Usage: /new <session_name>")
             else:
                 self.session.save()
                 self.session = Session(name=parts[1], model=self.session.model)
-                print(f"[new session '{self.session.name}' started]")
+                console.print(f"[new session '{self.session.name}' started]")
 
         elif cmd == "/switch":
             if len(parts) == 1:
@@ -152,24 +149,24 @@ class ChatCLI:
                     try:
                         self.session.save()
                         self.session = Session.load(selection)
-                        print(
+                        console.print(
                             f"[switched to session '{self.session.name}'] (model={self.session.model})"
                         )
                     except FileNotFoundError as exc:
-                        print(exc)
+                        console.print(exc)
                 return True
 
             if len(parts) != 2:
-                print("Usage: /switch <session_name>")
+                console.print("Usage: /switch <session_name>")
             else:
                 try:
                     self.session.save()
                     self.session = Session.load(parts[1])
-                    print(
+                    console.print(
                         f"[switched to session '{self.session.name}'] (model={self.session.model})"
                     )
                 except FileNotFoundError as exc:
-                    print(exc)
+                    console.print(exc)
 
         elif cmd == "/clear":
             # Remove all turn messages but keep system prompt
@@ -181,7 +178,7 @@ class ChatCLI:
                 self.client._last_response_id = None  # pylint: disable=protected-access
 
             self.session.save()
-            print("[conversation cleared – system prompt reinstated]")
+            console.print("[conversation cleared – system prompt reinstated]")
 
         elif cmd == "/tool":
             if (
@@ -189,19 +186,19 @@ class ChatCLI:
                 or parts[1].lower() != "websearch"
                 or parts[2] not in {"on", "off"}
             ):
-                print("Usage: /tool websearch on|off")
+                console.print("Usage: /tool websearch on|off")
             else:
                 self.session.enable_web_search = parts[2] == "on"
                 state = "enabled" if self.session.enable_web_search else "disabled"
-                print(f"[web search tool {state}]")
+                console.print(f"[web search tool {state}]")
 
         elif cmd == "/reasoning":
             if len(parts) != 2 or parts[1] not in {"on", "off"}:
-                print("Usage: /reasoning on|off")
+                console.print("Usage: /reasoning on|off")
             else:
                 self.session.enable_reasoning_summary = parts[1] == "on"
                 state = "enabled" if self.session.enable_reasoning_summary else "disabled"
-                print(f"[reasoning summaries {state}]")
+                console.print(f"[reasoning summaries {state}]")
 
         elif cmd == "/delete":
             if len(parts) == 1:
@@ -216,11 +213,11 @@ class ChatCLI:
             elif len(parts) == 2:
                 target = parts[1]
             else:
-                print("Usage: /delete <session_name>")
+                console.print("Usage: /delete <session_name>")
                 return True
 
             if target == self.session.name:
-                print(
+                console.print(
                     Ansi.style(
                         "Cannot delete the session you are currently using. Switch to another session first.",
                         Ansi.FG_RED,
@@ -230,18 +227,18 @@ class ChatCLI:
 
             path = Session.SESSIONS_DIR / f"{target}{Session.FILENAME_SUFFIX}"
             if not path.exists():
-                print(f"Session '{target}' does not exist.")
+                console.print(f"Session '{target}' does not exist.")
                 return True
 
             try:
                 path.unlink()
-                print(f"[session '{target}' deleted]")
+                console.print(f"[session '{target}' deleted]")
             except OSError as exc:
-                print(Ansi.style(f"Failed to delete session '{target}': {exc}", Ansi.FG_RED))
+                console.print(Ansi.style(f"Failed to delete session '{target}': {exc}", Ansi.FG_RED))
             return True
 
         else:
-            print(Ansi.style(f"Unknown command: {cmd} (see /help)", Ansi.FG_RED))
+            console.print(Ansi.style(f"Unknown command: {cmd} (see /help)", Ansi.FG_RED))
 
         return True
 
@@ -249,14 +246,9 @@ class ChatCLI:
 
     def repl(self) -> None:
         """Run the interactive read–eval–print-loop."""
-        banner_lines = [
-            Ansi.style(" ┌──────────────────────────────────────────────┐", Ansi.FG_MAGENTA),
-            Ansi.style(" │         OpenAI   Chat   CLI                │", Ansi.FG_MAGENTA, Ansi.BOLD),
-            Ansi.style(" └──────────────────────────────────────────────┘", Ansi.FG_MAGENTA),
-        ]
-        print("\n".join(banner_lines))
+        console.print(Panel.fit("OpenAI Chat CLI", style="bold magenta"))
 
-        print(
+        console.print(
             Ansi.style("Type your message and press Enter. Commands start with '/'.", Ansi.FG_YELLOW),
             Ansi.style(f"Current model: {self.session.model}.", Ansi.FG_YELLOW),
             Ansi.style("Type /help for help.", Ansi.FG_YELLOW),
@@ -265,10 +257,9 @@ class ChatCLI:
 
         while True:
             try:
-                prompt = readline_safe_prompt(f"{USER_LABEL}> ")
-                line = input(prompt).strip()
+                line = console.input(f"{USER_LABEL}> ").strip()
             except (EOFError, KeyboardInterrupt):
-                print("\n[signal caught – exiting]")
+                console.print("\n[signal caught – exiting]")
                 self.session.save()
                 break
 
@@ -320,7 +311,7 @@ def run_cli() -> None:  # pragma: no cover
     except FileNotFoundError:
         default_model = args.model or os.getenv("OPENAI_DEFAULT_MODEL", "gpt-4o")
         if default_model not in SUPPORTED_MODELS:
-            print(
+            console.print(
                 f"Warning: model '{default_model}' is not in the supported list. "
                 "Falling back to default 'gpt-4o'."
             )

--- a/chat_cli/core/client.py
+++ b/chat_cli/core/client.py
@@ -119,19 +119,20 @@ class OpenAIClientWrapper:
                         spinner.stop()
                         first_token_received = True
 
-                    print(delta.content, end="", flush=True)
+                    console.print(delta.content, end="")
+                    console.file.flush()
                     accumulator.append(delta.content)
 
                 if not first_token_received:
                     spinner.stop()
-                print()  # new line after stream ends
+                console.print()  # new line after stream ends
             except openai.OpenAIError as e:
                 spinner.stop()
-                print(f"\n[{ERROR_LABEL}] OpenAI API error: {e}\n")
+                console.print(f"\n[{ERROR_LABEL}] OpenAI API error: {e}\n")
                 return ""
             except KeyboardInterrupt:
                 spinner.stop()
-                print("\n[interrupted]")
+                console.print("\n[interrupted]")
                 return ""
 
             return "".join(accumulator)
@@ -180,9 +181,9 @@ class OpenAIClientWrapper:
                 self._extract_summary_from_response(resp) if enable_reasoning_summary else ""
             )
 
-            print(f"{aggregated_text}")
+            console.print(f"{aggregated_text}")
             if aggregated_summary:
-                print(f"{REASONING_LABEL}> {aggregated_summary}")
+                console.print(f"{REASONING_LABEL}> {aggregated_summary}")
 
             return aggregated_text
 
@@ -194,7 +195,7 @@ class OpenAIClientWrapper:
                 unsupported_features.append("reasoning summary")
 
             feature_list = " and ".join(unsupported_features) or "requested feature"
-            print(
+            console.print(
                 f"\n[{WARNING_LABEL}] {feature_list.capitalize()} failed or is not supported for model '{model}': {e}. "
                 "Retrying without unsupported features…\n"
             )
@@ -205,5 +206,5 @@ class OpenAIClientWrapper:
                 enable_reasoning_summary=False,
             )
         except KeyboardInterrupt:
-            print("\n[interrupted]")
+            console.print("\n[interrupted]")
             return "" 

--- a/chat_cli/core/session.py
+++ b/chat_cli/core/session.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Dict, Any
 
-from ..utils.ansi import Ansi
+from ..utils.ansi import Ansi, console
 
 # A single, persistent system message ensures the model is aware that it is
 # interacting in a terminal context and should optimise readability for that
@@ -108,13 +108,13 @@ class Session:
     def list_sessions(cls, current: Optional[str] = None) -> None:
         files = sorted(cls.SESSIONS_DIR.glob(f"*{cls.FILENAME_SUFFIX}"))
         if not files:
-            print("(no saved sessions)")
+            console.print("(no saved sessions)")
             return
-        print(Ansi.style("Saved sessions:", Ansi.BOLD, Ansi.FG_MAGENTA))
+        console.print(Ansi.style("Saved sessions:", Ansi.BOLD, Ansi.FG_MAGENTA))
         for file in files:
             name = file.stem
             updated = datetime.fromtimestamp(file.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S")
             indicator_char = "★" if current and name == current else " "
             colour = Ansi.FG_GREEN if indicator_char == "★" else Ansi.FG_CYAN
             label = Ansi.style(name, colour)
-            print(f"  {indicator_char} {label} (updated: {updated})")
+            console.print(f"  {indicator_char} {label} (updated: {updated})")

--- a/chat_cli/utils/__init__.py
+++ b/chat_cli/utils/__init__.py
@@ -1,4 +1,12 @@
-from .ansi import Ansi, USER_LABEL, ASSISTANT_LABEL, ERROR_LABEL, WARNING_LABEL, REASONING_LABEL
+from .ansi import (
+    Ansi,
+    USER_LABEL,
+    ASSISTANT_LABEL,
+    ERROR_LABEL,
+    WARNING_LABEL,
+    REASONING_LABEL,
+    console,
+)
 from .readline import readline_safe_prompt
 from .spinner import Spinner
 
@@ -9,6 +17,7 @@ __all__ = [
     "ERROR_LABEL",
     "WARNING_LABEL",
     "REASONING_LABEL",
+    "console",
     "readline_safe_prompt",
     "Spinner",
-] 
+]

--- a/chat_cli/utils/ansi.py
+++ b/chat_cli/utils/ansi.py
@@ -1,26 +1,30 @@
-"""ANSI color and styling utilities for terminal output."""
+"""Colour and styling helpers built on :mod:`rich`."""
 
 import os
+from rich.console import Console
+
+
+console = Console()
 
 
 class Ansi:
-    """Lightweight collection of ANSI escape codes we rely on."""
+    """Lightweight collection of style names used throughout the app."""
 
-    RESET = "\033[0m"
-    BOLD = "\033[1m"
+    BOLD = "bold"
 
-    FG_GREEN = "\033[92m"
-    FG_CYAN = "\033[96m"
-    FG_MAGENTA = "\033[95m"
-    FG_YELLOW = "\033[93m"
-    FG_RED = "\033[91m"
+    FG_GREEN = "green"
+    FG_CYAN = "cyan"
+    FG_MAGENTA = "magenta"
+    FG_YELLOW = "yellow"
+    FG_RED = "red"
 
     @staticmethod
     def style(text: str, *codes: str) -> str:
-        """Return `text` wrapped in the given ANSI codes unless NO_COLOR set."""
+        """Return *text* wrapped in rich markup unless ``NO_COLOR`` is set."""
         if os.getenv("NO_COLOR") is not None:
             return text
-        return "".join(codes) + text + Ansi.RESET
+        style = " ".join(codes)
+        return f"[{style}]{text}[/]"
 
 
 # Common labels used throughout the application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openai
+rich

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -13,8 +13,8 @@ class BaseChatCLITest(unittest.TestCase):
         self.sessions_dir_patcher = patch('chat_cli.core.session.Session.SESSIONS_DIR', self.test_sessions_dir)
         self.sessions_dir_patcher.start()
         
-        # Patch print to suppress command feedback
-        self.print_patcher = patch('builtins.print')
+        # Patch console.print to suppress command feedback
+        self.print_patcher = patch('chat_cli.utils.ansi.console.print')
         self.print_patcher.start()
         
         # Mock the OpenAI client


### PR DESCRIPTION
## Summary
- add `rich` to dependencies
- wrap color helpers around Rich Console
- use `rich` in CLI banners, input prompts and selection menus
- print session listings through `rich` console
- capture console output in unit tests

## Testing
- `python tests/run_tests.py` *(fails: ModuleNotFoundError: No module named 'rich')*