### PR TITLE
Fix spinner prefix markup rendering

### DIFF
--- a/chat_cli/utils/spinner.py
+++ b/chat_cli/utils/spinner.py
@@ -7,6 +7,8 @@ import threading
 import time
 from typing import Optional
 
+from .ansi import console
+
 try:
     from yaspin import yaspin  # type: ignore
 except Exception:  # pragma: no cover - optional dep may be missing
@@ -22,7 +24,7 @@ class Spinner:
         self._started = False
         if yaspin is not None:
             # spinner after the text so prefix stays at the start
-            self._spinner = yaspin(text=self._prefix, side="right")
+            self._spinner = yaspin(text="", side="right")
         else:
             self._cycle = itertools.cycle("|/-\\")
             self._stop_event = threading.Event()
@@ -31,18 +33,20 @@ class Spinner:
     def _spin(self) -> None:
         while not self._stop_event.is_set():
             ch = next(self._cycle)
-            sys.stdout.write(f"\r{self._prefix}{ch}")
-            sys.stdout.flush()
+            console.print(f"\r{self._prefix}{ch}", end="")
+            console.file.flush()
             time.sleep(self._delay)
 
     def start(self) -> None:
         if self._started:
             return
         if yaspin is not None:
+            console.print(self._prefix, end="")
+            console.file.flush()
             self._spinner.start()
         else:
-            sys.stdout.write(self._prefix)
-            sys.stdout.flush()
+            console.print(self._prefix, end="")
+            console.file.flush()
             self._thread = threading.Thread(target=self._spin, daemon=True)
             self._thread.start()
         self._started = True
@@ -52,12 +56,14 @@ class Spinner:
             return
         if yaspin is not None:
             self._spinner.stop()
+            console.print(f"\r{self._prefix}", end="")
+            console.file.flush()
         else:
             if self._thread:
                 self._stop_event.set()
                 self._thread.join()
                 self._thread = None
                 self._stop_event.clear()
-            sys.stdout.write(f"\r{self._prefix}")
-            sys.stdout.flush()
+            console.print(f"\r{self._prefix}", end="")
+            console.file.flush()
         self._started = False


### PR DESCRIPTION
## Summary
- ensure spinner uses rich console for styled prefixes

## Testing
- `python tests/run_tests.py` *(fails: ModuleNotFoundError: No module named 'rich')*